### PR TITLE
refactor: 리포트 생성 시 레디스 기반 리모트 캐시 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,9 @@ dependencies {
     // Database
     runtimeOnly 'com.mysql:mysql-connector-j'
 
-    // AI / LangChain
-    implementation 'dev.langchain4j:langchain4j:1.0.0-beta1'
-    implementation 'dev.langchain4j:langchain4j-google-ai-gemini:1.0.0-beta1'
+    // AI
+    implementation 'dev.langchain4j:langchain4j-open-ai:1.4.0'
+    implementation 'dev.langchain4j:langchain4j:1.4.0'
 
     // Web Scraping
     implementation 'org.jsoup:jsoup:1.15.3'

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ dependencies {
 
     // AI / LangChain
     implementation 'dev.langchain4j:langchain4j:1.0.0-beta1'
-    implementation 'dev.langchain4j:langchain4j-open-ai:1.0.0-beta1'
     implementation 'dev.langchain4j:langchain4j-google-ai-gemini:1.0.0-beta1'
 
     // Web Scraping

--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/datastreams_knu/bigpicture/alert/service/NewsAlertService.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/service/NewsAlertService.java
@@ -13,7 +13,7 @@ import datastreams_knu.bigpicture.common.exception.ObjectMapperException;
 import datastreams_knu.bigpicture.common.util.WebClientUtil;
 import datastreams_knu.bigpicture.news.exception.NewsCrawlingException;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
@@ -50,11 +50,11 @@ public class NewsAlertService {
     private final AiModelConfig aiModelConfig;
     private final ObjectMapper objectMapper;
 
-    private ChatLanguageModel model;
+    private ChatModel model;
 
     @PostConstruct
     public void init() {
-        this.model = aiModelConfig.geminiChatModel();
+        this.model = aiModelConfig.openAiChatModel();
     }
 
     public void sendNewsAlerts(LocalDateTime localDateTime) {

--- a/src/main/java/datastreams_knu/bigpicture/alert/service/NewsAlertService.java
+++ b/src/main/java/datastreams_knu/bigpicture/alert/service/NewsAlertService.java
@@ -54,7 +54,7 @@ public class NewsAlertService {
 
     @PostConstruct
     public void init() {
-        this.model = aiModelConfig.openAiChatModel();
+        this.model = aiModelConfig.geminiChatModel();
     }
 
     public void sendNewsAlerts(LocalDateTime localDateTime) {

--- a/src/main/java/datastreams_knu/bigpicture/common/advice/GlobalExceptionAdvice.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/advice/GlobalExceptionAdvice.java
@@ -2,6 +2,7 @@ package datastreams_knu.bigpicture.common.advice;
 
 import datastreams_knu.bigpicture.common.domain.ApiResponse;
 import datastreams_knu.bigpicture.common.exception.ObjectMapperException;
+import dev.langchain4j.exception.InternalServerException;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -43,6 +44,15 @@ public class GlobalExceptionAdvice {
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(UncheckedIOException.class)
     public ApiResponse<Object> uncheckedIOException(UncheckedIOException e) {
+        return ApiResponse.of(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                e.getMessage()
+        );
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(InternalServerException.class)
+    public ApiResponse<Object> internalServerExceptionException(InternalServerException e) {
         return ApiResponse.of(
                 HttpStatus.INTERNAL_SERVER_ERROR,
                 e.getMessage()

--- a/src/main/java/datastreams_knu/bigpicture/common/config/AiModelConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/config/AiModelConfig.java
@@ -1,7 +1,7 @@
 package datastreams_knu.bigpicture.common.config;
 
-import dev.langchain4j.model.chat.ChatLanguageModel;
-import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiChatModelName;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,14 +9,14 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class AiModelConfig {
 
-    @Value("${gemini.api.key}")
-    public String GEMINI_API_KEY;
+    @Value("${openai.api.key}")
+    private String OPENAI_API_KEY;
 
     @Bean
-    public ChatLanguageModel geminiChatModel() {
-        return GoogleAiGeminiChatModel.builder()
-                .apiKey(GEMINI_API_KEY)
-                .modelName("gemini-2.0-flash")
+    public OpenAiChatModel openAiChatModel() {
+        return OpenAiChatModel.builder()
+                .apiKey(OPENAI_API_KEY)
+                .modelName(OpenAiChatModelName.GPT_4_O_MINI)
                 .build();
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/common/config/AiModelConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/config/AiModelConfig.java
@@ -2,34 +2,15 @@ package datastreams_knu.bigpicture.common.config;
 
 import dev.langchain4j.model.chat.ChatLanguageModel;
 import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
-import dev.langchain4j.model.openai.OpenAiChatModel;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.time.Duration;
-
-import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O;
-import static dev.langchain4j.model.openai.OpenAiChatModelName.GPT_4_O_MINI;
-
 @Configuration
 public class AiModelConfig {
 
-    @Value("${openai.api.key}")
-    public String OPENAI_API_KEY;
-
     @Value("${gemini.api.key}")
     public String GEMINI_API_KEY;
-
-    @Bean
-    public ChatLanguageModel openAiChatModel() {
-        return OpenAiChatModel.builder()
-                .apiKey(OPENAI_API_KEY)
-                .modelName(GPT_4_O)
-                .timeout(Duration.ofSeconds(120))
-                .strictTools(true)
-                .build();
-    }
 
     @Bean
     public ChatLanguageModel geminiChatModel() {

--- a/src/main/java/datastreams_knu/bigpicture/common/util/TickerParser.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/util/TickerParser.java
@@ -6,7 +6,7 @@ import datastreams_knu.bigpicture.common.config.AiModelConfig;
 import datastreams_knu.bigpicture.common.exception.ObjectMapperException;
 import datastreams_knu.bigpicture.schedule.service.dto.RecommendedKeywordDto;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -20,11 +20,11 @@ public class TickerParser {
     private final AiModelConfig aiModelConfig;
     private final ObjectMapper objectMapper;
 
-    private ChatLanguageModel model;
+    private ChatModel model;
 
     @PostConstruct
     public void init() {
-        this.model = aiModelConfig.geminiChatModel();
+        this.model = aiModelConfig.openAiChatModel();
     }
 
     public String parseTicker(String ticker) {

--- a/src/main/java/datastreams_knu/bigpicture/common/util/TickerParser.java
+++ b/src/main/java/datastreams_knu/bigpicture/common/util/TickerParser.java
@@ -24,7 +24,7 @@ public class TickerParser {
 
     @PostConstruct
     public void init() {
-        this.model = aiModelConfig.openAiChatModel();
+        this.model = aiModelConfig.geminiChatModel();
     }
 
     public String parseTicker(String ticker) {

--- a/src/main/java/datastreams_knu/bigpicture/exchange/config/ExchangeCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/exchange/config/ExchangeCrawlingConfig.java
@@ -18,7 +18,7 @@ public class ExchangeCrawlingConfig {
     @Bean
     public ExchangeCrawlingAssistant exchangeCrawlingAssistant() {
         return AiServices.builder(ExchangeCrawlingAssistant.class)
-                .chatLanguageModel(aiModelConfig.geminiChatModel())
+                .chatModel(aiModelConfig.openAiChatModel())
                 .tools(exchangeCrawlingAgent)
                 .build();
     }

--- a/src/main/java/datastreams_knu/bigpicture/exchange/config/ExchangeCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/exchange/config/ExchangeCrawlingConfig.java
@@ -18,7 +18,7 @@ public class ExchangeCrawlingConfig {
     @Bean
     public ExchangeCrawlingAssistant exchangeCrawlingAssistant() {
         return AiServices.builder(ExchangeCrawlingAssistant.class)
-                .chatLanguageModel(aiModelConfig.openAiChatModel())
+                .chatLanguageModel(aiModelConfig.geminiChatModel())
                 .tools(exchangeCrawlingAgent)
                 .build();
     }

--- a/src/main/java/datastreams_knu/bigpicture/interest/config/InterestCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/config/InterestCrawlingConfig.java
@@ -18,7 +18,7 @@ public class InterestCrawlingConfig {
     @Bean
     public InterestCrawlingAssistant interestCrawlingAssistant() {
         return AiServices.builder(InterestCrawlingAssistant.class)
-                .chatLanguageModel(aiModelConfig.geminiChatModel())
+                .chatModel(aiModelConfig.openAiChatModel())
                 .tools(interestCrawlingAgent)
                 .build();
     }

--- a/src/main/java/datastreams_knu/bigpicture/interest/config/InterestCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/interest/config/InterestCrawlingConfig.java
@@ -18,7 +18,7 @@ public class InterestCrawlingConfig {
     @Bean
     public InterestCrawlingAssistant interestCrawlingAssistant() {
         return AiServices.builder(InterestCrawlingAssistant.class)
-                .chatLanguageModel(aiModelConfig.openAiChatModel())
+                .chatLanguageModel(aiModelConfig.geminiChatModel())
                 .tools(interestCrawlingAgent)
                 .build();
     }

--- a/src/main/java/datastreams_knu/bigpicture/news/agent/NewsCrawlingAgent.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/agent/NewsCrawlingAgent.java
@@ -50,7 +50,7 @@ public class NewsCrawlingAgent {
 
     @PostConstruct
     public void init() {
-        this.model = aiModelConfig.openAiChatModel();
+        this.model = aiModelConfig.geminiChatModel();
     }
 
     @Tool("keyword를 기반으로 keyword 관련 뉴스 기사를 검색합니다.")

--- a/src/main/java/datastreams_knu/bigpicture/news/agent/NewsCrawlingAgent.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/agent/NewsCrawlingAgent.java
@@ -16,7 +16,7 @@ import datastreams_knu.bigpicture.news.exception.NewsCrawlingException;
 import datastreams_knu.bigpicture.news.repository.NewsRepository;
 import dev.langchain4j.agent.tool.Tool;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -46,11 +46,11 @@ public class NewsCrawlingAgent {
     private final ObjectMapper objectMapper;
     private final NewsRepository newsRepository;
 
-    private ChatLanguageModel model;
+    private ChatModel model;
 
     @PostConstruct
     public void init() {
-        this.model = aiModelConfig.geminiChatModel();
+        this.model = aiModelConfig.openAiChatModel();
     }
 
     @Tool("keyword를 기반으로 keyword 관련 뉴스 기사를 검색합니다.")

--- a/src/main/java/datastreams_knu/bigpicture/news/config/NewsCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/config/NewsCrawlingConfig.java
@@ -18,7 +18,7 @@ public class NewsCrawlingConfig {
     @Bean
     public NewsCrawlingAssistant newsCrawlingAssistant() {
         return AiServices.builder(NewsCrawlingAssistant.class)
-                .chatLanguageModel(aiModelConfig.openAiChatModel())
+                .chatLanguageModel(aiModelConfig.geminiChatModel())
                 .tools(newsCrawlingAgent)
                 .build();
     }

--- a/src/main/java/datastreams_knu/bigpicture/news/config/NewsCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/config/NewsCrawlingConfig.java
@@ -18,7 +18,7 @@ public class NewsCrawlingConfig {
     @Bean
     public NewsCrawlingAssistant newsCrawlingAssistant() {
         return AiServices.builder(NewsCrawlingAssistant.class)
-                .chatLanguageModel(aiModelConfig.geminiChatModel())
+                .chatModel(aiModelConfig.openAiChatModel())
                 .tools(newsCrawlingAgent)
                 .build();
     }

--- a/src/main/java/datastreams_knu/bigpicture/news/service/NewsCrawlingService.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/service/NewsCrawlingService.java
@@ -56,7 +56,7 @@ public class NewsCrawlingService {
     @PostConstruct
     public void init() {
         this.newsCrawlingAssistant = newsCrawlingConfig.newsCrawlingAssistant();
-        this.model = aiModelConfig.openAiChatModel();
+        this.model = aiModelConfig.geminiChatModel();
     }
 
     @Transactional

--- a/src/main/java/datastreams_knu/bigpicture/news/service/NewsCrawlingService.java
+++ b/src/main/java/datastreams_knu/bigpicture/news/service/NewsCrawlingService.java
@@ -17,7 +17,7 @@ import datastreams_knu.bigpicture.news.entity.Reference;
 import datastreams_knu.bigpicture.news.exception.NewsCrawlingException;
 import datastreams_knu.bigpicture.news.repository.NewsRepository;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,12 +51,12 @@ public class NewsCrawlingService {
     private final NewsRepository newsRepository;
 
     private NewsCrawlingAssistant newsCrawlingAssistant;
-    private ChatLanguageModel model;
+    private ChatModel model;
 
     @PostConstruct
     public void init() {
         this.newsCrawlingAssistant = newsCrawlingConfig.newsCrawlingAssistant();
-        this.model = aiModelConfig.geminiChatModel();
+        this.model = aiModelConfig.openAiChatModel();
     }
 
     @Transactional

--- a/src/main/java/datastreams_knu/bigpicture/report/controller/ReportController.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/controller/ReportController.java
@@ -2,7 +2,7 @@ package datastreams_knu.bigpicture.report.controller;
 
 import datastreams_knu.bigpicture.common.domain.ApiResponse;
 import datastreams_knu.bigpicture.report.controller.dto.CreateReportRequest;
-import datastreams_knu.bigpicture.report.service.ReportService;
+import datastreams_knu.bigpicture.report.facade.ReportFacade;
 import datastreams_knu.bigpicture.report.service.dto.CreateReportResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,11 +18,11 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "레포트", description = "레포트 관련 API")
 public class ReportController {
 
-    private final ReportService reportService;
+    private final ReportFacade reportFacade;
 
     @PostMapping
     @Operation(summary = "레포트 생성", description = "레포트 생성")
     public ApiResponse<CreateReportResponse> createReport(@RequestBody CreateReportRequest request) {
-        return ApiResponse.ok(reportService.createReport(request.toServiceRequest()));
+        return ApiResponse.ok(reportFacade.getReport(request.toServiceRequest()));
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/report/controller/dto/CreateReportRequest.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/controller/dto/CreateReportRequest.java
@@ -17,29 +17,16 @@ public class CreateReportRequest {
     // reportType이 economy인 경우는 "", stock인 경우는 stockName(주식명 or 티커)
     String stockName;
 
-    // 위험 수용 성향
-    String riskTolerance;
-    // 레포트 난이도
-    String reportDifficultyLevel;
-    // 관심 분야
-    List<String> interestAreas;
-
     @Builder
-    public CreateReportRequest(String reportType, String stockName, String riskTolerance, String reportDifficultyLevel, List<String> interestAreas) {
+    public CreateReportRequest(String reportType, String stockName) {
         this.reportType = reportType;
         this.stockName = stockName;
-        this.riskTolerance = riskTolerance;
-        this.reportDifficultyLevel = reportDifficultyLevel;
-        this.interestAreas = interestAreas;
     }
 
     public CreateReportServiceRequest toServiceRequest() {
         return CreateReportServiceRequest.builder()
                 .reportType(reportType)
                 .stockName(stockName)
-                .riskTolerance(riskTolerance)
-                .reportDifficultyLevel(reportDifficultyLevel)
-                .interestAreas(interestAreas)
                 .build();
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/report/facade/ReportFacade.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/facade/ReportFacade.java
@@ -1,19 +1,106 @@
 package datastreams_knu.bigpicture.report.facade;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import datastreams_knu.bigpicture.report.service.ReportService;
 import datastreams_knu.bigpicture.report.service.dto.CreateReportResponse;
 import datastreams_knu.bigpicture.report.service.dto.CreateReportServiceRequest;
+import datastreams_knu.bigpicture.report.util.LockProvider;
+import dev.langchain4j.exception.InternalServerException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ReportFacade {
 
+    private static final String CACHE_KEY = "report";
+    private static final String LOCK_KEY = "lock-report";
+
+    public static final int RETRY_COUNT = 1000;
+    public static final int LOCK_TIMEOUT_MS = 60000;
+
     private final ReportService reportService;
 
+    private final LockProvider lockProvider;
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ObjectMapper objectMapper;
+
     public CreateReportResponse getReport(CreateReportServiceRequest request) {
-        CreateReportResponse report = reportService.createReport(request);
-        return report;
+        String reportType = request.getReportType();
+        String stockName = request.getStockName();
+
+        StringBuilder cacheKeyBuilder = new StringBuilder(CACHE_KEY).append(":").append(reportType);
+        if ("stock".equals(reportType)) {
+            cacheKeyBuilder.append(":").append(stockName);
+        }
+        String cacheKey = cacheKeyBuilder.toString();
+
+        StringBuilder lockKeyBuilder = new StringBuilder(LOCK_KEY).append(":").append(reportType);
+        if ("stock".equals(reportType)) {
+            lockKeyBuilder.append(":").append(stockName);
+        }
+        String lockKey = lockKeyBuilder.toString();
+
+
+        // 1. 캐시 확인
+        String cachedData = redisTemplate.opsForValue().get(cacheKey);
+        if (cachedData != null) {
+            try {
+                return objectMapper.readValue(cachedData, CreateReportResponse.class);
+            } catch (JsonProcessingException e) {
+                log.error("CachedData parsing error : {}", cacheKey, e);
+            }
+        }
+
+        // 2. 분산 락 획득 시도
+        for (int retry = 0; retry < RETRY_COUNT; retry++) {
+            boolean lockAcquired = lockProvider.tryLock(lockKey, LOCK_TIMEOUT_MS);
+            // 3. 랜덤 지터만큼 대기
+            if (!lockAcquired) {
+                long jitter = ThreadLocalRandom.current().nextLong(200, 300);
+                try {
+                    Thread.sleep(jitter);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                continue;
+            }
+
+            try {
+                // 4. Double-Checked Locking
+                cachedData = redisTemplate.opsForValue().get(cacheKey);
+                if (cachedData != null) {
+                    try {
+                        return objectMapper.readValue(cachedData, CreateReportResponse.class);
+                    } catch (JsonProcessingException e) {
+                        log.error("CachedData parsing error : {}", cacheKey, e);
+                    }
+                }
+
+                // 5. 데이터 처리
+                CreateReportResponse report = reportService.createReport(request);
+
+                // 6. 캐시 저장
+                try {
+                    redisTemplate.opsForValue().set(cacheKey, objectMapper.writeValueAsString(report), 24, TimeUnit.HOURS);
+                } catch (JsonProcessingException e) {
+                    log.error("CalculatedSentimentScore serializing error : {}", cacheKey, e);
+                }
+
+                return report;
+            } finally {
+                // 7. 락 반환
+                lockProvider.releaseLock(LOCK_KEY);
+            }
+        }
+        throw new InternalServerException("잠시 후 다시 리포트 생성을 시도해주세요.");
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/report/facade/ReportFacade.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/facade/ReportFacade.java
@@ -1,0 +1,19 @@
+package datastreams_knu.bigpicture.report.facade;
+
+import datastreams_knu.bigpicture.report.service.ReportService;
+import datastreams_knu.bigpicture.report.service.dto.CreateReportResponse;
+import datastreams_knu.bigpicture.report.service.dto.CreateReportServiceRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ReportFacade {
+
+    private final ReportService reportService;
+
+    public CreateReportResponse getReport(CreateReportServiceRequest request) {
+        CreateReportResponse report = reportService.createReport(request);
+        return report;
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/report/service/ReportService.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/service/ReportService.java
@@ -14,7 +14,7 @@ import datastreams_knu.bigpicture.schedule.repository.CrawlingInfoRepository;
 import datastreams_knu.bigpicture.stock.entity.Stock;
 import datastreams_knu.bigpicture.stock.repository.StockRepository;
 import dev.langchain4j.data.message.UserMessage;
-import dev.langchain4j.model.chat.ChatLanguageModel;
+import dev.langchain4j.model.chat.ChatModel;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,11 +44,11 @@ public class ReportService {
 
     private final AiModelConfig aiModelConfig;
 
-    private ChatLanguageModel model;
+    private ChatModel model;
 
     @PostConstruct
     public void init() {
-        this.model = aiModelConfig.geminiChatModel();
+        this.model = aiModelConfig.openAiChatModel();
     }
 
     // 개인화된 파라미터를 없애고 reportType, stockName으로만 리포트 생성

--- a/src/main/java/datastreams_knu/bigpicture/report/service/dto/CreateReportResponse.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/service/dto/CreateReportResponse.java
@@ -3,6 +3,7 @@ package datastreams_knu.bigpicture.report.service.dto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @NoArgsConstructor
 @Getter

--- a/src/main/java/datastreams_knu/bigpicture/report/service/dto/CreateReportServiceRequest.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/service/dto/CreateReportServiceRequest.java
@@ -3,8 +3,6 @@ package datastreams_knu.bigpicture.report.service.dto;
 import lombok.Builder;
 import lombok.Getter;
 
-import java.util.List;
-
 @Getter
 public class CreateReportServiceRequest {
     // economy, stock
@@ -12,29 +10,16 @@ public class CreateReportServiceRequest {
     // reportType이 economy인 경우는 "", stock인 경우는 stockName(주식명 or 티커)
     String stockName;
 
-    // 위험 수용 성향
-    String riskTolerance;
-    // 레포트 난이도
-    String reportDifficultyLevel;
-    // 관심 분야
-    List<String> interestAreas;
-
     @Builder
-    public CreateReportServiceRequest(String reportType, String stockName, String riskTolerance, String reportDifficultyLevel, List<String> interestAreas) {
+    public CreateReportServiceRequest(String reportType, String stockName) {
         this.reportType = reportType;
         this.stockName = stockName;
-        this.riskTolerance = riskTolerance;
-        this.reportDifficultyLevel = reportDifficultyLevel;
-        this.interestAreas = interestAreas;
     }
 
-    public static CreateReportServiceRequest of(String reportType, String stockName, String riskTolerance, String reportDifficultyLevel, List<String> interestAreas) {
+    public static CreateReportServiceRequest of(String reportType, String stockName) {
         return CreateReportServiceRequest.builder()
                 .reportType(reportType)
                 .stockName(stockName)
-                .riskTolerance(riskTolerance)
-                .reportDifficultyLevel(reportDifficultyLevel)
-                .interestAreas(interestAreas)
                 .build();
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/report/util/DistributedLockProvider.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/util/DistributedLockProvider.java
@@ -1,0 +1,23 @@
+package datastreams_knu.bigpicture.report.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class DistributedLockProvider implements LockProvider {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public boolean tryLock(String key, long timeoutMs) {
+        Boolean success = redisTemplate.opsForValue().setIfAbsent(key, "locked", timeoutMs, TimeUnit.MILLISECONDS);
+        return Boolean.TRUE.equals(success);
+    }
+
+    public void releaseLock(String key) {
+        redisTemplate.delete(key);
+    }
+}

--- a/src/main/java/datastreams_knu/bigpicture/report/util/LockProvider.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/util/LockProvider.java
@@ -1,0 +1,8 @@
+package datastreams_knu.bigpicture.report.util;
+
+public interface LockProvider {
+
+    boolean tryLock(String key, long timeoutMs);
+
+    void releaseLock(String key);
+}

--- a/src/main/java/datastreams_knu/bigpicture/report/util/ReportPrompt.java
+++ b/src/main/java/datastreams_knu/bigpicture/report/util/ReportPrompt.java
@@ -40,8 +40,6 @@ public abstract class ReportPrompt {
             - 미국 금리 정보: {%s}
             - 경제 뉴스: {%s}
                         
-            %s
-                        
             [출력 형식]
             아래 형식의 레포트만 반환하세요. 다른 텍스트나 설명은 절대 포함하지 마세요.
                        
@@ -94,8 +92,6 @@ public abstract class ReportPrompt {
             - 한국 금리 정보: {%s}
             - 미국 금리 정보: {%s}
             - 경제 뉴스: {%s}
-                        
-            %s
 
             [출력 형식]
             아래 형식의 **순수한 JSON만 반환하세요.** 다른 텍스트나 설명은 절대 포함하지 마세요.
@@ -168,8 +164,6 @@ public abstract class ReportPrompt {
             - 주가 정보: {%s}
             - 주식 뉴스: {%s}
                         
-            %s
-                        
             [출력 형식]
             아래 형식의 레포트만 반환하세요. 다른 텍스트나 설명은 절대 포함하지 마세요.
                         
@@ -237,8 +231,6 @@ public abstract class ReportPrompt {
             - 경제 레포트: {%s}
             - 주가 정보: {%s}
             - 주식 뉴스: {%s}
-                        
-            %s
 
             [출력 형식]
             아래 형식의 **순수한 JSON만 반환하세요.** 다른 텍스트나 설명은 절대 포함하지 마세요.
@@ -301,8 +293,6 @@ public abstract class ReportPrompt {
             [입력 데이터]
             - 레포트: {%s}
                         
-            %s
-                        
             [출력 형식]
             아래 형식의 레포트만 반환하세요. 다른 텍스트나 설명은 절대 포함하지 마세요.
                         
@@ -362,8 +352,6 @@ public abstract class ReportPrompt {
             [입력 데이터]
             - 레포트: {%s}
                         
-            %s
-                        
             [출력 형식]
             아래 형식의 레포트만 반환하세요. 다른 텍스트나 설명은 절대 포함하지 마세요.
                         
@@ -416,8 +404,6 @@ public abstract class ReportPrompt {
             [입력 데이터]
             - 경제/주식 요약 레포트: {%s}
             - 레포트: {%s}
-                        
-            %s
 
             [출력 형식]
             아래 형식의 **순수한 JSON만 반환하세요.** 다른 텍스트나 설명은 절대 포함하지 마세요.
@@ -463,8 +449,6 @@ public abstract class ReportPrompt {
             [입력 데이터]
             - 레포트: {%s}
 
-            %s
-
             [출력 형식]
             제목 문자열만 반환하세요. 다른 텍스트나 설명은 절대 포함하지 마세요.
 
@@ -500,8 +484,6 @@ public abstract class ReportPrompt {
             [입력 데이터]
             - 제목: {%s}
             - 레포트: {%s}
-
-            %s
 
             [출력 형식]  
             아래 형식의 **순수한 JSON만 반환하세요.** 다른 텍스트나 설명은 절대 포함하지 마세요.

--- a/src/main/java/datastreams_knu/bigpicture/schedule/scheduler/CrawlingScheduler.java
+++ b/src/main/java/datastreams_knu/bigpicture/schedule/scheduler/CrawlingScheduler.java
@@ -2,6 +2,7 @@ package datastreams_knu.bigpicture.schedule.scheduler;
 
 import datastreams_knu.bigpicture.schedule.service.CrawlingSchedulerService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Component;
 public class CrawlingScheduler {
 
     private final CrawlingSchedulerService crawlingSchedulerService;
+    private final RedisTemplate<String, String> redisTemplate;
 
     // 달러 환율 크롤링
     @Scheduled(cron = "0 10 23 * * SUN", zone = "Asia/Seoul") // 매주 일요일 오후 11시 10분
@@ -51,5 +53,11 @@ public class CrawlingScheduler {
     @Scheduled(cron = "0 0 4 * * *", zone = "Asia/Seoul") // 매일 오전 4시
     public void runCrawlingSeedCrawling() {
         crawlingSchedulerService.crawlingSeedCrawling();
+    }
+
+    // 리포트 캐시 초기화
+    @Scheduled(cron = "0 0 6 * * *", zone = "Asia/Seoul") // 매일 오전 6시
+    public void resetReportCache() {
+        redisTemplate.getConnectionFactory().getConnection().flushAll();
     }
 }

--- a/src/main/java/datastreams_knu/bigpicture/stock/config/StockCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/config/StockCrawlingConfig.java
@@ -18,7 +18,7 @@ public class StockCrawlingConfig {
     @Bean
     public StockCrawlingAssistant stockCrawlingAssistant() {
         return AiServices.builder(StockCrawlingAssistant.class)
-                .chatLanguageModel(aiModelConfig.openAiChatModel())
+                .chatLanguageModel(aiModelConfig.geminiChatModel())
                 .tools(stockCrawlingAgent)
                 .build();
     }

--- a/src/main/java/datastreams_knu/bigpicture/stock/config/StockCrawlingConfig.java
+++ b/src/main/java/datastreams_knu/bigpicture/stock/config/StockCrawlingConfig.java
@@ -18,7 +18,7 @@ public class StockCrawlingConfig {
     @Bean
     public StockCrawlingAssistant stockCrawlingAssistant() {
         return AiServices.builder(StockCrawlingAssistant.class)
-                .chatLanguageModel(aiModelConfig.geminiChatModel())
+                .chatModel(aiModelConfig.openAiChatModel())
                 .tools(stockCrawlingAgent)
                 .build();
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=BigPicture
 spring.profiles.active=secret
+
 # MySQL
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}?useSSL=false&serverTimezone=Asia/Seoul&allowPublicKeyRetrieval=true
 spring.datasource.username=${MYSQL_USER}
@@ -7,6 +8,11 @@ spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=create
+
+# REDIS
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+
 # API BASE-URLS
 ecos.api.base-url=https://ecos.bok.or.kr/api/StatisticSearch/
 fred.api.base-url=https://api.stlouisfed.org/fred/series/observations

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,5 +1,6 @@
 spring.application.name=BigPicture
 spring.profiles.active=test
+
 # MySQL
 spring.datasource.url=jdbc:mysql://${MYSQL_HOST}:${MYSQL_PORT}/${MYSQL_DATABASE}
 spring.datasource.username=${MYSQL_USER}
@@ -7,6 +8,11 @@ spring.datasource.password=${MYSQL_PASSWORD}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 spring.jpa.hibernate.ddl-auto=create
+
+# REDIS
+spring.data.redis.host=${REDIS_HOST}
+spring.data.redis.port=${REDIS_PORT}
+
 # API BASE-URLS
 ecos.api.base-url=https://ecos.bok.or.kr/api/StatisticSearch/
 fred.api.base-url=https://api.stlouisfed.org/fred/series/observations


### PR DESCRIPTION
## #️⃣ 연관된 이슈
x


## 📝 작업 내용
### 캐시
- 리포트 생성 시 너무 많은 시간이 걸려 캐싱을 통해 만들어진 결과를 재활용하고자 세부 파라미터들을 제거하였습니다.
- `double checked locking` 방식을 통해 캐싱의 `hot-key` 문제를 방지하였습니다.
- `double checked locking` 방식 구현시 사용한 분산락은 레디스의 `set nx`를 통해 구현하였습니다.

- 캐시 재시도 횟수와 대기 랜덤 지터에 대한 생각
    - >레디스 리모트 캐시를 적용하려 하는데, hot key 문제를 방지하기 위해 락을 획득한 후에도 반드시 캐시를 한 번 더 확인하는 방식을 적용 즉 Double Checked Locking 패턴을 적용하려 하는데, 이때 락을 획득하지 못한 애들은 일정 시간후에 다시 락 획득을 시도해야 함. 그런데 지금 디비에 접근해서 하는 task가 넉넉하게 1분정도 걸리는데, 이 때문에 락 획득 간격을 너무 길게 잡아버리면 ux가 저하되고 그렇다고 너무 짧게 잡으면 요청 실패가 빈번하게 발생하게 됨. 그렇다고 또 시도횟수를 늘리면 또 서비스에 부하가 발생할 수 있음.

- 현재는 재시도 횟수 최대 1000번에 랜덤 지터 200~300ms로 최소 200000ms(3분 20초)를 대기하도록 설정해놓은 상태입니다.
- 캐시를 통해 이미 만들어진 리포트에 대해 응답시간이 **29872ms &rarr; 190ms** 로 개선되었습니다.
### langchain4j
- langchain4j의 **정식 릴리즈 버전**을 적용하였습니다.

### 스크린샷 (선택)
x

## 💬 리뷰 요구사항(선택)
x


## ⏰ 현재 버그
x

## ✏ Git Close
x